### PR TITLE
feat: Add Home API service and models for specialization and doctors

### DIFF
--- a/doc_app/ios/Podfile.lock
+++ b/doc_app/ios/Podfile.lock
@@ -2,20 +2,34 @@ PODS:
   - Flutter (1.0.0)
   - flutter_native_splash (2.4.3):
     - Flutter
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  sqflite_darwin:
+    :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
 PODFILE CHECKSUM: 981a5a4f6fab455d5ca6de58d93f51dd252bb107
 

--- a/doc_app/lib/core/dependeny_injection/dependeny_injection.dart
+++ b/doc_app/lib/core/dependeny_injection/dependeny_injection.dart
@@ -1,6 +1,9 @@
 import 'package:dio/dio.dart';
 import 'package:doc_app/core/networking/api_service.dart';
 import 'package:doc_app/core/networking/dio_factory.dart';
+import 'package:doc_app/features/home/data/api/home_api_service.dart';
+import 'package:doc_app/features/home/data/repository/home_repository_impl.dart';
+import 'package:doc_app/features/home/logic/repository/home_repository.dart';
 import 'package:doc_app/features/login/data/repository/login_repository_impl.dart';
 import 'package:doc_app/features/login/logic/cubit/login_cubit.dart';
 import 'package:doc_app/features/login/logic/repository/login_repository.dart';
@@ -16,6 +19,14 @@ void setUpGetIt() {
   getIt.registerLazySingleton<ApiService>(() => ApiService(dio));
   _login();
   _signUp();
+  _home(dio);
+}
+
+_home(Dio dio) {
+  getIt.registerLazySingleton<HomeApiService>(() => HomeApiService(dio));
+  getIt.registerLazySingleton<HomeRepository>(
+    () => HomeRepositoryImplmentation(getIt()),
+  );
 }
 
 _signUp() {

--- a/doc_app/lib/core/networking/api_constants.dart
+++ b/doc_app/lib/core/networking/api_constants.dart
@@ -2,6 +2,8 @@ class ApiConstants {
   static const apiBaseUrl = 'https://vcare.integration25.com/api/';
   static const login = 'auth/login';
   static const signUp = 'auth/register';
+  static const specializationDoctors = 'specialization/index';
+
 }
 
 class ApiErrors {

--- a/doc_app/lib/core/networking/dio_factory.dart
+++ b/doc_app/lib/core/networking/dio_factory.dart
@@ -11,11 +11,19 @@ class DioFactory {
       dio!
         ..options.connectTimeout = timeOut
         ..options.receiveTimeout = timeOut;
+      addDioHeaders();
       addDioInterceptor();
       return dio!;
     } else {
       return dio!;
     }
+  }
+
+  static void addDioHeaders() {
+    dio?.options.headers.addAll({
+      'Authorization': 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3ZjYXJlLmludGVncmF0aW9uMjUuY29tL2FwaS9hdXRoL3JlZ2lzdGVyIiwiaWF0IjoxNzQ5OTk3ODY1LCJleHAiOjE3NTAwODQyNjUsIm5iZiI6MTc0OTk5Nzg2NSwianRpIjoiYm5pRGFFRmk1bFVNWmtZbiIsInN1YiI6IjQxMTAiLCJwcnYiOiIyM2JkNWM4OTQ5ZjYwMGFkYjM5ZTcwMWM0MDA4NzJkYjdhNTk3NmY3In0.V48DCHy-8DWgfjYFMlmvB2Y19q7kDGJZs5jmnV33xfI',
+      'Accept': 'application/json'
+    });
   }
 
   static void addDioInterceptor() {

--- a/doc_app/lib/core/router/app_router.dart
+++ b/doc_app/lib/core/router/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:doc_app/core/dependeny_injection/dependeny_injection.dart';
 import 'package:doc_app/core/router/router_strings.dart';
+import 'package:doc_app/features/home/logic/cubit/home_cubit.dart';
 import 'package:doc_app/features/home/ui/home_view.dart';
 import 'package:doc_app/features/login/logic/cubit/login_cubit.dart';
 import 'package:doc_app/features/onboarding/screen/onboarding_screen.dart';
@@ -27,7 +28,13 @@ class AppRouter {
       case RouterStrings.splash:
         return MaterialPageRoute(builder: (_) => SplashView());
       case RouterStrings.home:
-        return MaterialPageRoute(builder: (_) => HomeView());
+        return MaterialPageRoute(
+          builder:
+              (_) => BlocProvider(
+                create: (context) => HomeCubit(getIt())..getDoctorsBySpecialization(),
+                child: HomeView(),
+              ),
+        );
       case RouterStrings.signUp:
         return MaterialPageRoute(
           builder:

--- a/doc_app/lib/features/home/data/api/home_api_service.dart
+++ b/doc_app/lib/features/home/data/api/home_api_service.dart
@@ -1,0 +1,14 @@
+import 'package:dio/dio.dart';
+import 'package:doc_app/core/networking/api_constants.dart';
+import 'package:doc_app/features/home/data/models/specialization_model.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'home_api_service.g.dart';
+
+@RestApi(baseUrl: ApiConstants.apiBaseUrl)
+abstract class HomeApiService {
+  factory HomeApiService(Dio dio) = _HomeApiService;
+
+  @GET(ApiConstants.specializationDoctors)
+  Future<SpecializationModel> getAllSpecialization();
+}

--- a/doc_app/lib/features/home/data/api/home_api_service.g.dart
+++ b/doc_app/lib/features/home/data/api/home_api_service.g.dart
@@ -1,0 +1,88 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'home_api_service.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element
+
+class _HomeApiService implements HomeApiService {
+  _HomeApiService(
+    this._dio, {
+    this.baseUrl,
+    this.errorLogger,
+  }) {
+    baseUrl ??= 'https://vcare.integration25.com/api/';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<SpecializationModel> getAllSpecialization() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<SpecializationModel>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          'specialization/index',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late SpecializationModel _value;
+    try {
+      _value = SpecializationModel.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(
+    String dioBaseUrl,
+    String? baseUrl,
+  ) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/doc_app/lib/features/home/data/models/specialization_model.dart
+++ b/doc_app/lib/features/home/data/models/specialization_model.dart
@@ -1,0 +1,15 @@
+import 'package:doc_app/features/home/data/models/sub_models/specialization_doctor_model.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'specialization_model.g.dart';
+
+@JsonSerializable()
+class SpecializationModel {
+  String? message;
+  @JsonKey(name: 'data')
+  List<SpecializationDoctorsModel>? specializationDoctors;
+  SpecializationModel({this.message, this.specializationDoctors});
+  factory SpecializationModel.fromJson(Map<String, dynamic> json) =>
+      _$SpecializationModelFromJson(json);
+  Map<String, dynamic> toJson() => _$SpecializationModelToJson(this);
+}

--- a/doc_app/lib/features/home/data/models/specialization_model.g.dart
+++ b/doc_app/lib/features/home/data/models/specialization_model.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'specialization_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SpecializationModel _$SpecializationModelFromJson(Map<String, dynamic> json) =>
+    SpecializationModel(
+      message: json['message'] as String?,
+      specializationDoctors: (json['data'] as List<dynamic>?)
+          ?.map((e) =>
+              SpecializationDoctorsModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$SpecializationModelToJson(
+        SpecializationModel instance) =>
+    <String, dynamic>{
+      'message': instance.message,
+      'data': instance.specializationDoctors,
+    };

--- a/doc_app/lib/features/home/data/models/sub_models/city_model.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/city_model.dart
@@ -1,0 +1,14 @@
+import 'package:doc_app/features/home/data/models/sub_models/governrate_model.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'city_model.g.dart';
+
+@JsonSerializable()
+class City {
+  int? id;
+  String? name;
+  GovernrateModel? governrate;
+  City({required this.id, required this.name, this.governrate});
+  factory City.fromJson(Map<String, dynamic> json) => _$CityFromJson(json);
+  Map<String, dynamic> toJson() => _$CityToJson(this);
+}

--- a/doc_app/lib/features/home/data/models/sub_models/city_model.g.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/city_model.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'city_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+City _$CityFromJson(Map<String, dynamic> json) => City(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+      governrate: json['governrate'] == null
+          ? null
+          : GovernrateModel.fromJson(
+              json['governrate'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$CityToJson(City instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'governrate': instance.governrate,
+    };

--- a/doc_app/lib/features/home/data/models/sub_models/doctor_model.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/doctor_model.dart
@@ -1,0 +1,46 @@
+import 'package:doc_app/features/home/data/models/sub_models/city_model.dart';
+import 'package:doc_app/features/home/data/models/sub_models/specialization_model.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'doctor_model.g.dart';
+
+@JsonSerializable()
+class DoctorsModel {
+  int? id;
+  String? name;
+  String? email;
+  String? phone;
+  String? photo;
+  String? gender;
+  String? address;
+  String? description;
+  String? degree;
+  Specialization? specialization;
+  City? city;
+  @JsonKey(name: 'appoint_price')
+  int? appointPrice;
+  @JsonKey(name: 'start_time')
+  String? startTime;
+  @JsonKey(name: 'end_time')
+  String? endTime;
+  DoctorsModel({
+    this.id,
+    this.name,
+    this.email,
+    this.phone,
+    this.photo,
+    this.gender,
+    this.address,
+    this.description,
+    this.degree,
+    this.specialization,
+    this.city,
+    this.appointPrice,
+    this.startTime,
+    this.endTime,
+  });
+
+  factory DoctorsModel.fromJson(Map<String, dynamic> json) =>
+      _$DoctorsModelFromJson(json);
+  Map<String, dynamic> toJson() => _$DoctorsModelToJson(this);
+}

--- a/doc_app/lib/features/home/data/models/sub_models/doctor_model.g.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/doctor_model.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'doctor_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DoctorsModel _$DoctorsModelFromJson(Map<String, dynamic> json) => DoctorsModel(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+      email: json['email'] as String?,
+      phone: json['phone'] as String?,
+      photo: json['photo'] as String?,
+      gender: json['gender'] as String?,
+      address: json['address'] as String?,
+      description: json['description'] as String?,
+      degree: json['degree'] as String?,
+      specialization: json['specialization'] == null
+          ? null
+          : Specialization.fromJson(
+              json['specialization'] as Map<String, dynamic>),
+      city: json['city'] == null
+          ? null
+          : City.fromJson(json['city'] as Map<String, dynamic>),
+      appointPrice: (json['appoint_price'] as num?)?.toInt(),
+      startTime: json['start_time'] as String?,
+      endTime: json['end_time'] as String?,
+    );
+
+Map<String, dynamic> _$DoctorsModelToJson(DoctorsModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'email': instance.email,
+      'phone': instance.phone,
+      'photo': instance.photo,
+      'gender': instance.gender,
+      'address': instance.address,
+      'description': instance.description,
+      'degree': instance.degree,
+      'specialization': instance.specialization,
+      'city': instance.city,
+      'appoint_price': instance.appointPrice,
+      'start_time': instance.startTime,
+      'end_time': instance.endTime,
+    };

--- a/doc_app/lib/features/home/data/models/sub_models/governrate_model.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/governrate_model.dart
@@ -1,0 +1,13 @@
+
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'governrate_model.g.dart';
+@JsonSerializable()
+class GovernrateModel {
+  int ?id;
+  String ?name;
+  GovernrateModel({this.id, this.name});
+  factory GovernrateModel.fromJson(Map<String, dynamic> json) =>
+      _$GovernrateModelFromJson(json);
+  Map<String, dynamic> toJson() => _$GovernrateModelToJson(this);
+}

--- a/doc_app/lib/features/home/data/models/sub_models/governrate_model.g.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/governrate_model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'governrate_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GovernrateModel _$GovernrateModelFromJson(Map<String, dynamic> json) =>
+    GovernrateModel(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+    );
+
+Map<String, dynamic> _$GovernrateModelToJson(GovernrateModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+    };

--- a/doc_app/lib/features/home/data/models/sub_models/specialization_doctor_model.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/specialization_doctor_model.dart
@@ -1,0 +1,14 @@
+import 'package:doc_app/features/home/data/models/sub_models/doctor_model.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'specialization_doctor_model.g.dart';
+@JsonSerializable()
+class SpecializationDoctorsModel {
+  int? id;
+  String? name;
+  List<DoctorsModel>? doctors;
+  SpecializationDoctorsModel({this.id, this.name, this.doctors});
+  factory SpecializationDoctorsModel.fromJson(Map<String, dynamic> json) =>
+      _$SpecializationDoctorsModelFromJson(json);
+  Map<String, dynamic> toJson() => _$SpecializationDoctorsModelToJson(this);
+}

--- a/doc_app/lib/features/home/data/models/sub_models/specialization_doctor_model.g.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/specialization_doctor_model.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'specialization_doctor_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SpecializationDoctorsModel _$SpecializationDoctorsModelFromJson(
+        Map<String, dynamic> json) =>
+    SpecializationDoctorsModel(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+      doctors: (json['doctors'] as List<dynamic>?)
+          ?.map((e) => DoctorsModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$SpecializationDoctorsModelToJson(
+        SpecializationDoctorsModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'doctors': instance.doctors,
+    };

--- a/doc_app/lib/features/home/data/models/sub_models/specialization_model.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/specialization_model.dart
@@ -1,0 +1,13 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'specialization_model.g.dart';
+@JsonSerializable()
+class Specialization {
+  int? id;
+  String? name;
+
+  Specialization({required this.id, required this.name});
+  factory Specialization.fromJson(Map<String, dynamic> json) =>
+      _$SpecializationFromJson(json);
+  Map<String, dynamic> toJson() => _$SpecializationToJson(this);
+}

--- a/doc_app/lib/features/home/data/models/sub_models/specialization_model.g.dart
+++ b/doc_app/lib/features/home/data/models/sub_models/specialization_model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'specialization_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Specialization _$SpecializationFromJson(Map<String, dynamic> json) =>
+    Specialization(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+    );
+
+Map<String, dynamic> _$SpecializationToJson(Specialization instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+    };

--- a/doc_app/lib/features/home/data/repository/home_repository_impl.dart
+++ b/doc_app/lib/features/home/data/repository/home_repository_impl.dart
@@ -1,0 +1,20 @@
+import 'package:doc_app/core/networking/api_error_handler.dart';
+import 'package:doc_app/core/networking/api_result.dart';
+import 'package:doc_app/features/home/data/api/home_api_service.dart';
+import 'package:doc_app/features/home/data/models/specialization_model.dart';
+import 'package:doc_app/features/home/logic/repository/home_repository.dart';
+
+class HomeRepositoryImplmentation extends HomeRepository {
+  final HomeApiService _homeApiService;
+  HomeRepositoryImplmentation(this._homeApiService);
+
+  @override
+  Future<ApiResult<SpecializationModel>> getAllSpecialization() async {
+    try {
+      final result = await _homeApiService.getAllSpecialization();
+      return ApiResult.success(result);
+    } catch (error) {
+      return ApiResult.failure(ErrorHandler.handle(error));
+    }
+  }
+}

--- a/doc_app/lib/features/home/logic/cubit/home_cubit.dart
+++ b/doc_app/lib/features/home/logic/cubit/home_cubit.dart
@@ -1,0 +1,24 @@
+import 'package:bloc/bloc.dart';
+import 'package:doc_app/features/home/logic/cubit/home_state.dart';
+import 'package:doc_app/features/home/logic/repository/home_repository.dart';
+
+class HomeCubit extends Cubit<HomeState> {
+  HomeCubit(this.homeRepository) : super(HomeState.initial());
+  final HomeRepository homeRepository;
+
+  getDoctorsBySpecialization() async {
+    emit(HomeState.doctorSpecializationLoading());
+
+    final responce = await homeRepository.getAllSpecialization();
+    responce.when(
+      success: (success) {
+        emit(
+          HomeState.doctorSpecializationLoaded(success.specializationDoctors),
+        );
+      },
+      failure: (failure) {
+        emit(HomeState.doctorSpecializationError(failure));
+      },
+    );
+  }
+}

--- a/doc_app/lib/features/home/logic/cubit/home_state.dart
+++ b/doc_app/lib/features/home/logic/cubit/home_state.dart
@@ -1,0 +1,12 @@
+import 'package:doc_app/core/networking/api_error_handler.dart';
+import 'package:doc_app/features/home/data/models/sub_models/specialization_doctor_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'home_state.freezed.dart';
+
+@freezed
+class HomeState with _$HomeState {
+  const factory HomeState.initial() = _Initial;
+  const factory HomeState.doctorSpecializationLoading() = DoctorSpecializationLoading;
+  const factory HomeState.doctorSpecializationLoaded(List<SpecializationDoctorsModel> ?doctors) = DoctorSpecializationLoaded;
+  const factory HomeState.doctorSpecializationError(ErrorHandler ? message) = DoctorSpecializationError;
+}

--- a/doc_app/lib/features/home/logic/cubit/home_state.freezed.dart
+++ b/doc_app/lib/features/home/logic/cubit/home_state.freezed.dart
@@ -1,0 +1,710 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'home_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$HomeState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() doctorSpecializationLoading,
+    required TResult Function(List<SpecializationDoctorsModel>? doctors)
+        doctorSpecializationLoaded,
+    required TResult Function(ErrorHandler? message) doctorSpecializationError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? doctorSpecializationLoading,
+    TResult? Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult? Function(ErrorHandler? message)? doctorSpecializationError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? doctorSpecializationLoading,
+    TResult Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult Function(ErrorHandler? message)? doctorSpecializationError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(DoctorSpecializationLoading value)
+        doctorSpecializationLoading,
+    required TResult Function(DoctorSpecializationLoaded value)
+        doctorSpecializationLoaded,
+    required TResult Function(DoctorSpecializationError value)
+        doctorSpecializationError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult? Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult? Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HomeStateCopyWith<$Res> {
+  factory $HomeStateCopyWith(HomeState value, $Res Function(HomeState) then) =
+      _$HomeStateCopyWithImpl<$Res, HomeState>;
+}
+
+/// @nodoc
+class _$HomeStateCopyWithImpl<$Res, $Val extends HomeState>
+    implements $HomeStateCopyWith<$Res> {
+  _$HomeStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$InitialImplCopyWith<$Res> {
+  factory _$$InitialImplCopyWith(
+          _$InitialImpl value, $Res Function(_$InitialImpl) then) =
+      __$$InitialImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InitialImplCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$InitialImpl>
+    implements _$$InitialImplCopyWith<$Res> {
+  __$$InitialImplCopyWithImpl(
+      _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$InitialImpl implements _Initial {
+  const _$InitialImpl();
+
+  @override
+  String toString() {
+    return 'HomeState.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitialImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() doctorSpecializationLoading,
+    required TResult Function(List<SpecializationDoctorsModel>? doctors)
+        doctorSpecializationLoaded,
+    required TResult Function(ErrorHandler? message) doctorSpecializationError,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? doctorSpecializationLoading,
+    TResult? Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult? Function(ErrorHandler? message)? doctorSpecializationError,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? doctorSpecializationLoading,
+    TResult Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult Function(ErrorHandler? message)? doctorSpecializationError,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(DoctorSpecializationLoading value)
+        doctorSpecializationLoading,
+    required TResult Function(DoctorSpecializationLoaded value)
+        doctorSpecializationLoaded,
+    required TResult Function(DoctorSpecializationError value)
+        doctorSpecializationError,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult? Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult? Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initial implements HomeState {
+  const factory _Initial() = _$InitialImpl;
+}
+
+/// @nodoc
+abstract class _$$DoctorSpecializationLoadingImplCopyWith<$Res> {
+  factory _$$DoctorSpecializationLoadingImplCopyWith(
+          _$DoctorSpecializationLoadingImpl value,
+          $Res Function(_$DoctorSpecializationLoadingImpl) then) =
+      __$$DoctorSpecializationLoadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$DoctorSpecializationLoadingImplCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$DoctorSpecializationLoadingImpl>
+    implements _$$DoctorSpecializationLoadingImplCopyWith<$Res> {
+  __$$DoctorSpecializationLoadingImplCopyWithImpl(
+      _$DoctorSpecializationLoadingImpl _value,
+      $Res Function(_$DoctorSpecializationLoadingImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$DoctorSpecializationLoadingImpl implements DoctorSpecializationLoading {
+  const _$DoctorSpecializationLoadingImpl();
+
+  @override
+  String toString() {
+    return 'HomeState.doctorSpecializationLoading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DoctorSpecializationLoadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() doctorSpecializationLoading,
+    required TResult Function(List<SpecializationDoctorsModel>? doctors)
+        doctorSpecializationLoaded,
+    required TResult Function(ErrorHandler? message) doctorSpecializationError,
+  }) {
+    return doctorSpecializationLoading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? doctorSpecializationLoading,
+    TResult? Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult? Function(ErrorHandler? message)? doctorSpecializationError,
+  }) {
+    return doctorSpecializationLoading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? doctorSpecializationLoading,
+    TResult Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult Function(ErrorHandler? message)? doctorSpecializationError,
+    required TResult orElse(),
+  }) {
+    if (doctorSpecializationLoading != null) {
+      return doctorSpecializationLoading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(DoctorSpecializationLoading value)
+        doctorSpecializationLoading,
+    required TResult Function(DoctorSpecializationLoaded value)
+        doctorSpecializationLoaded,
+    required TResult Function(DoctorSpecializationError value)
+        doctorSpecializationError,
+  }) {
+    return doctorSpecializationLoading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult? Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult? Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+  }) {
+    return doctorSpecializationLoading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+    required TResult orElse(),
+  }) {
+    if (doctorSpecializationLoading != null) {
+      return doctorSpecializationLoading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class DoctorSpecializationLoading implements HomeState {
+  const factory DoctorSpecializationLoading() =
+      _$DoctorSpecializationLoadingImpl;
+}
+
+/// @nodoc
+abstract class _$$DoctorSpecializationLoadedImplCopyWith<$Res> {
+  factory _$$DoctorSpecializationLoadedImplCopyWith(
+          _$DoctorSpecializationLoadedImpl value,
+          $Res Function(_$DoctorSpecializationLoadedImpl) then) =
+      __$$DoctorSpecializationLoadedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({List<SpecializationDoctorsModel>? doctors});
+}
+
+/// @nodoc
+class __$$DoctorSpecializationLoadedImplCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$DoctorSpecializationLoadedImpl>
+    implements _$$DoctorSpecializationLoadedImplCopyWith<$Res> {
+  __$$DoctorSpecializationLoadedImplCopyWithImpl(
+      _$DoctorSpecializationLoadedImpl _value,
+      $Res Function(_$DoctorSpecializationLoadedImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? doctors = freezed,
+  }) {
+    return _then(_$DoctorSpecializationLoadedImpl(
+      freezed == doctors
+          ? _value._doctors
+          : doctors // ignore: cast_nullable_to_non_nullable
+              as List<SpecializationDoctorsModel>?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$DoctorSpecializationLoadedImpl implements DoctorSpecializationLoaded {
+  const _$DoctorSpecializationLoadedImpl(
+      final List<SpecializationDoctorsModel>? doctors)
+      : _doctors = doctors;
+
+  final List<SpecializationDoctorsModel>? _doctors;
+  @override
+  List<SpecializationDoctorsModel>? get doctors {
+    final value = _doctors;
+    if (value == null) return null;
+    if (_doctors is EqualUnmodifiableListView) return _doctors;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString() {
+    return 'HomeState.doctorSpecializationLoaded(doctors: $doctors)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DoctorSpecializationLoadedImpl &&
+            const DeepCollectionEquality().equals(other._doctors, _doctors));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_doctors));
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DoctorSpecializationLoadedImplCopyWith<_$DoctorSpecializationLoadedImpl>
+      get copyWith => __$$DoctorSpecializationLoadedImplCopyWithImpl<
+          _$DoctorSpecializationLoadedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() doctorSpecializationLoading,
+    required TResult Function(List<SpecializationDoctorsModel>? doctors)
+        doctorSpecializationLoaded,
+    required TResult Function(ErrorHandler? message) doctorSpecializationError,
+  }) {
+    return doctorSpecializationLoaded(doctors);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? doctorSpecializationLoading,
+    TResult? Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult? Function(ErrorHandler? message)? doctorSpecializationError,
+  }) {
+    return doctorSpecializationLoaded?.call(doctors);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? doctorSpecializationLoading,
+    TResult Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult Function(ErrorHandler? message)? doctorSpecializationError,
+    required TResult orElse(),
+  }) {
+    if (doctorSpecializationLoaded != null) {
+      return doctorSpecializationLoaded(doctors);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(DoctorSpecializationLoading value)
+        doctorSpecializationLoading,
+    required TResult Function(DoctorSpecializationLoaded value)
+        doctorSpecializationLoaded,
+    required TResult Function(DoctorSpecializationError value)
+        doctorSpecializationError,
+  }) {
+    return doctorSpecializationLoaded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult? Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult? Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+  }) {
+    return doctorSpecializationLoaded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+    required TResult orElse(),
+  }) {
+    if (doctorSpecializationLoaded != null) {
+      return doctorSpecializationLoaded(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class DoctorSpecializationLoaded implements HomeState {
+  const factory DoctorSpecializationLoaded(
+          final List<SpecializationDoctorsModel>? doctors) =
+      _$DoctorSpecializationLoadedImpl;
+
+  List<SpecializationDoctorsModel>? get doctors;
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DoctorSpecializationLoadedImplCopyWith<_$DoctorSpecializationLoadedImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$DoctorSpecializationErrorImplCopyWith<$Res> {
+  factory _$$DoctorSpecializationErrorImplCopyWith(
+          _$DoctorSpecializationErrorImpl value,
+          $Res Function(_$DoctorSpecializationErrorImpl) then) =
+      __$$DoctorSpecializationErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({ErrorHandler? message});
+}
+
+/// @nodoc
+class __$$DoctorSpecializationErrorImplCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$DoctorSpecializationErrorImpl>
+    implements _$$DoctorSpecializationErrorImplCopyWith<$Res> {
+  __$$DoctorSpecializationErrorImplCopyWithImpl(
+      _$DoctorSpecializationErrorImpl _value,
+      $Res Function(_$DoctorSpecializationErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = freezed,
+  }) {
+    return _then(_$DoctorSpecializationErrorImpl(
+      freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ErrorHandler?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$DoctorSpecializationErrorImpl implements DoctorSpecializationError {
+  const _$DoctorSpecializationErrorImpl(this.message);
+
+  @override
+  final ErrorHandler? message;
+
+  @override
+  String toString() {
+    return 'HomeState.doctorSpecializationError(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DoctorSpecializationErrorImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DoctorSpecializationErrorImplCopyWith<_$DoctorSpecializationErrorImpl>
+      get copyWith => __$$DoctorSpecializationErrorImplCopyWithImpl<
+          _$DoctorSpecializationErrorImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() doctorSpecializationLoading,
+    required TResult Function(List<SpecializationDoctorsModel>? doctors)
+        doctorSpecializationLoaded,
+    required TResult Function(ErrorHandler? message) doctorSpecializationError,
+  }) {
+    return doctorSpecializationError(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? doctorSpecializationLoading,
+    TResult? Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult? Function(ErrorHandler? message)? doctorSpecializationError,
+  }) {
+    return doctorSpecializationError?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? doctorSpecializationLoading,
+    TResult Function(List<SpecializationDoctorsModel>? doctors)?
+        doctorSpecializationLoaded,
+    TResult Function(ErrorHandler? message)? doctorSpecializationError,
+    required TResult orElse(),
+  }) {
+    if (doctorSpecializationError != null) {
+      return doctorSpecializationError(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(DoctorSpecializationLoading value)
+        doctorSpecializationLoading,
+    required TResult Function(DoctorSpecializationLoaded value)
+        doctorSpecializationLoaded,
+    required TResult Function(DoctorSpecializationError value)
+        doctorSpecializationError,
+  }) {
+    return doctorSpecializationError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult? Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult? Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+  }) {
+    return doctorSpecializationError?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(DoctorSpecializationLoading value)?
+        doctorSpecializationLoading,
+    TResult Function(DoctorSpecializationLoaded value)?
+        doctorSpecializationLoaded,
+    TResult Function(DoctorSpecializationError value)?
+        doctorSpecializationError,
+    required TResult orElse(),
+  }) {
+    if (doctorSpecializationError != null) {
+      return doctorSpecializationError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class DoctorSpecializationError implements HomeState {
+  const factory DoctorSpecializationError(final ErrorHandler? message) =
+      _$DoctorSpecializationErrorImpl;
+
+  ErrorHandler? get message;
+
+  /// Create a copy of HomeState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DoctorSpecializationErrorImplCopyWith<_$DoctorSpecializationErrorImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/doc_app/lib/features/home/logic/repository/home_repository.dart
+++ b/doc_app/lib/features/home/logic/repository/home_repository.dart
@@ -1,0 +1,6 @@
+import 'package:doc_app/core/networking/api_result.dart';
+import 'package:doc_app/features/home/data/models/specialization_model.dart';
+
+abstract class HomeRepository {
+  Future<ApiResult<SpecializationModel>> getAllSpecialization();
+}

--- a/doc_app/lib/features/home/ui/home_view.dart
+++ b/doc_app/lib/features/home/ui/home_view.dart
@@ -3,9 +3,8 @@ import 'package:doc_app/core/helper/spaceing.dart';
 import 'package:doc_app/core/theme/app_colors.dart';
 import 'package:doc_app/core/theme/app_text_style.dart';
 import 'package:doc_app/features/home/ui/widgets/doctor_blue_container.dart';
-import 'package:doc_app/features/home/ui/widgets/doctor_speciality_list_view.dart';
+import 'package:doc_app/features/home/ui/widgets/doctor_specializations_bloc_builder.dart';
 import 'package:doc_app/features/home/ui/widgets/home_view_top_bar.dart';
-import 'package:doc_app/features/home/ui/widgets/recommendation_listview.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
@@ -42,26 +41,7 @@ class HomeView extends StatelessWidget {
                 ],
               ),
               verticalSpace(16),
-              DoctorSpecialityListView(),
-              verticalSpace(23),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    AppStrings.recommendationDoctor,
-                    style: AppTextStyle.interSemiBoldSize18White.copyWith(
-                      color: AppColors.darkBlue,
-                    ),
-                  ),
-                  Text(
-                    AppStrings.seeAll,
-                    style: AppTextStyle.interRegualarSize12PrimColor,
-                  ),
-                ],
-              ),
-              verticalSpace(15),
-
-              RecommendationDoctorListView(),
+              SpecializationsBlocBuilder(),
             ],
           ),
         ),

--- a/doc_app/lib/features/home/ui/widgets/doctor_container_background_and_text.dart
+++ b/doc_app/lib/features/home/ui/widgets/doctor_container_background_and_text.dart
@@ -17,7 +17,7 @@ class DoctorContainerBackgoundAndText extends StatelessWidget {
       height: 170.h,
       decoration: BoxDecoration(
         image: DecorationImage(
-          image: AssetImage(Assets.svgDoctorContainerBackGroundImage ,),
+          image: AssetImage(Assets.svgDoctorContainerBackGroundImage),
           fit: BoxFit.cover,
         ),
         borderRadius: BorderRadius.circular(24.r),

--- a/doc_app/lib/features/home/ui/widgets/doctor_specializations_bloc_builder.dart
+++ b/doc_app/lib/features/home/ui/widgets/doctor_specializations_bloc_builder.dart
@@ -1,0 +1,81 @@
+import 'package:doc_app/core/constant/app_strings.dart';
+import 'package:doc_app/core/helper/spaceing.dart';
+import 'package:doc_app/core/networking/api_error_handler.dart';
+import 'package:doc_app/core/theme/app_colors.dart';
+import 'package:doc_app/core/theme/app_text_style.dart';
+import 'package:doc_app/features/home/data/models/sub_models/specialization_doctor_model.dart';
+import 'package:doc_app/features/home/logic/cubit/home_cubit.dart';
+import 'package:doc_app/features/home/logic/cubit/home_state.dart';
+import 'package:doc_app/features/home/ui/widgets/doctor_speciality_list_view.dart';
+import 'package:doc_app/features/home/ui/widgets/recommendation_listview.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class SpecializationsBlocBuilder extends StatelessWidget {
+  const SpecializationsBlocBuilder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<HomeCubit, HomeState>(
+      buildWhen: (previous, current) {
+        return current is DoctorSpecializationLoading ||
+            current is DoctorSpecializationLoaded ||
+            current is DoctorSpecializationError;
+      },
+      builder: (context, state) {
+        return state.maybeWhen(
+          doctorSpecializationLoaded: (doctors) {
+            return doctorSpecialistLoaded(doctors: doctors);
+          },
+
+          doctorSpecializationLoading: () => doctorSpecialistLoading(),
+          doctorSpecializationError: (message) => doctorSpecialistFailure(message: message),
+          orElse: () => const SizedBox.shrink(),
+        );
+      },
+    );
+  }
+
+  Widget doctorSpecialistLoaded({
+    required List<SpecializationDoctorsModel>? doctors,
+  }) {
+    return Expanded(
+      child: Column(
+        children: [
+          DoctorSpecialityListView(),
+          verticalSpace(23),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                AppStrings.recommendationDoctor,
+                style: AppTextStyle.interSemiBoldSize18White.copyWith(
+                  color: AppColors.darkBlue,
+                ),
+              ),
+              Text(
+                AppStrings.seeAll,
+                style: AppTextStyle.interRegualarSize12PrimColor,
+              ),
+            ],
+          ),
+          verticalSpace(15),
+          RecommendationDoctorListView(doctors: doctors?[0].doctors ?? []),
+        ],
+      ),
+    );
+  }
+
+  Widget doctorSpecialistLoading() {
+    return const Center(child: CircularProgressIndicator());
+  }
+
+  Widget doctorSpecialistFailure({ErrorHandler? message}) {
+    return Center(
+      child: Text(
+        message?.apiErrorModel.message ?? 'Error occurred',
+        style: AppTextStyle.interBoldSize18BDarkBlueColor,
+      ),
+    );
+  }
+}

--- a/doc_app/lib/features/home/ui/widgets/recommendation_listview.dart
+++ b/doc_app/lib/features/home/ui/widgets/recommendation_listview.dart
@@ -1,25 +1,30 @@
 import 'package:doc_app/core/helper/spaceing.dart';
+import 'package:doc_app/features/home/data/models/sub_models/doctor_model.dart';
 import 'package:doc_app/features/home/ui/widgets/recommendation_listview_content.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class RecommendationDoctorListView extends StatelessWidget {
-  const RecommendationDoctorListView({super.key});
+  const RecommendationDoctorListView({super.key, required this.doctors});
+  final List<DoctorsModel>? doctors;
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
       child: ListView.separated(
-        itemBuilder: (index, context) {
+        itemBuilder: (context, index) {
           return Container(
             width: double.infinity,
             height: 126.h,
             decoration: BoxDecoration(borderRadius: BorderRadius.circular(8.r)),
-            child: RecommendationDoctorListViewContent(),
+            child: RecommendationDoctorListViewItem(
+              currentIndex: index,
+              doctors: doctors,
+            ),
           );
         },
-        separatorBuilder: (index, context) => verticalSpace(16),
-        itemCount: 8,
+        separatorBuilder: (context, index) => verticalSpace(16),
+        itemCount: doctors?.length ?? 0,
       ),
     );
   }

--- a/doc_app/lib/features/home/ui/widgets/recommendation_listview_content.dart
+++ b/doc_app/lib/features/home/ui/widgets/recommendation_listview_content.dart
@@ -1,33 +1,42 @@
-import 'package:doc_app/core/constant/assets_strings.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:doc_app/core/helper/spaceing.dart';
 import 'package:doc_app/core/theme/app_colors.dart';
 import 'package:doc_app/core/theme/app_text_style.dart';
+import 'package:doc_app/features/home/data/models/sub_models/doctor_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-class RecommendationDoctorListViewContent extends StatelessWidget {
-  const RecommendationDoctorListViewContent({super.key});
+class RecommendationDoctorListViewItem extends StatelessWidget {
+   RecommendationDoctorListViewItem({super.key, this.doctors ,required this.currentIndex});
+  final List<DoctorsModel> ?doctors;
+ final  int currentIndex;
+
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Image.asset(Assets.imagesDoctorImage, width: 110.w, height: 110.h),
-
+        CachedNetworkImage(
+          imageUrl: "https://upload.wikimedia.org/wikipedia/commons/e/e2/Sadio_Man%C3%A9_-_Persepolis_F.C._v_Al_Nassr_FC%2C_19_September_2023.jpg",
+          progressIndicatorBuilder:
+              (context, url, downloadProgress) =>
+                  CircularProgressIndicator(value: downloadProgress.progress),
+          errorWidget: (context, url, error) => Icon(Icons.error),
+        ),
         horizontalSpace(12),
         Column(
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              "Dr. Randy Wigham",
+              doctors?[currentIndex].name ?? "No Name",
               style: AppTextStyle.interBoldSize18BDarkBlueColor.copyWith(
                 fontSize: 16.sp,
               ),
             ),
             verticalSpace(4),
             Text(
-              "RSUD Gatot Subroto",
+             doctors?[currentIndex].email ?? "No Email",
               style: AppTextStyle.interRegualarSize12PrimColor.copyWith(
                 color: AppColors.grey,
               ),

--- a/doc_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/doc_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_foundation
+import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/doc_app/pubspec.lock
+++ b/doc_app/pubspec.lock
@@ -134,6 +134,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.9.5"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -275,6 +299,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.1.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -525,6 +557,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -549,6 +589,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.17"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -557,6 +645,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:
@@ -629,6 +733,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shelf:
     dependency: transitive
     description:
@@ -674,6 +786,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -706,6 +866,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -754,6 +922,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vector_graphics:
     dependency: transitive
     description:
@@ -826,6 +1002,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:
@@ -844,4 +1028,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.27.0"

--- a/doc_app/pubspec.yaml
+++ b/doc_app/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   retrofit: ^4.0.3
   retrofit_generator: ^8.0.4
   flutter_bloc: ^9.1.0
+  cached_network_image: ^3.4.1
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
- Implemented HomeApiService to fetch all specializations from the API.
- Created data models for Specialization, Doctors, City, and Governrate.
- Added JSON serialization support using json_annotation.
- Developed HomeRepository implementation to handle API calls.
- Introduced HomeCubit for state management of doctor specializations.
- Built UI components to display doctor specializations using Bloc pattern.
- Integrated error handling for API responses.

![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-15 at 18 18 01](https://github.com/user-attachments/assets/636325e6-8ddc-4c4c-aefb-0541365daaae)

